### PR TITLE
Portman Hokkaido routine fix

### DIFF
--- a/content/SmallFixes/chunk22/portman_glass_patch.entity.patch.json
+++ b/content/SmallFixes/chunk22/portman_glass_patch.entity.patch.json
@@ -1,0 +1,1 @@
+{"tempHash":"009AAFAC5EA2ABC8","tbluHash":"003032578D699567","patch":[{"SubEntityOperation":["838a9c506f0446e8",{"RemoveEventConnection":["OnStart","Start","ba2bf9ec88c6a958"]}]},{"SubEntityOperation":["838a9c506f0446e8",{"AddEventConnection":["OnStart","Start","838a9c506f0446e8"]}]}],"patchVersion":6}


### PR DESCRIPTION
Jason Portman in Hokkaido has an action where he is drinking a wine at the bar area. It is the very last action before he hears the announcement (happens during the action) and goes to the clinic. Problem is, due to the typo/mistake in IDs, in vanilla game he is using an action of simply standing nearby and inspecting a sakura tree, as if his glass was destroyed. Just fixing the action ID actually restores this part of his routine. Quite a curious bug, wonder how it never got discovered

Also my first PR, so please tell me if I did something wrong. Appreciate that